### PR TITLE
[feature]: Add sender whitelist filtering with rejected/per-sender folders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ POLL_INTERVAL=5
 
 # Output Configuration
 OUTPUT_DIR=
+
+# Sender Whitelist (comma-separated email addresses)
+SENDER_WHITELIST=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-01-29
+
+### Added
+
+- Sender whitelist via `SENDER_WHITELIST` env var (comma-separated, case-insensitive)
+- Non-whitelisted emails moved to `Rejected` IMAP folder
+- Per-sender subfolders under `Processed` (e.g., `Processed/user@example_com`)
+- IMAP namespace delimiter detection for folder naming
+
+### Changed
+
+- `mark_as_processed()` now accepts `EmailMessage` instead of `uid: int`
+- `_ensure_processed_folder()` replaced by `_ensure_folders()` and `_ensure_folder()`
+- Whitelist check runs before `_parse_email`, preventing disk writes for rejected senders
+- Empty/unset `SENDER_WHITELIST` rejects all emails (strict default)
+
 ## [0.2.0] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Email-based audio transcription service. Send an audio file, receive a transcrip
 | `IMAP_PORT` | IMAP server port | `993` |
 | `IMAP_USERNAME` | IMAP login username | (required) |
 | `IMAP_PASSWORD` | IMAP login password | (required) |
+| `SENDER_WHITELIST` | Comma-separated allowed sender emails | (empty = reject all) |
 | `POLL_INTERVAL` | Seconds between inbox checks | `5` |
 | `FFMPEG_PATH` | Path to ffmpeg binary | system default |
 | `OUTPUT_DIR` | Directory for transcription output | (required) |
@@ -58,7 +59,7 @@ Email-based audio transcription service. Send an audio file, receive a transcrip
 - `src/transcription.py` - audio-to-text via OpenAI Whisper API with ffmpeg normalization
 - `src/email_client.py` - IMAP connection, inbox polling, audio attachment extraction
 
-Processed emails are moved from INBOX to a `Processed` folder.
+Emails from whitelisted senders are processed and moved to `Processed/<sender>`. Non-whitelisted emails are moved to `Rejected`. Unset or empty `SENDER_WHITELIST` rejects all emails.
 
 ## Usage
 

--- a/src/email_client.py
+++ b/src/email_client.py
@@ -3,6 +3,7 @@ import email
 import logging
 import os
 from email.message import Message
+from email.utils import parseaddr
 from pathlib import Path
 
 from imapclient import IMAPClient
@@ -10,6 +11,7 @@ from imapclient import IMAPClient
 SUPPORTED_AUDIO_FORMATS = {".mp3", ".wav", ".m4a", ".ogg"}
 DEFAULT_POLL_INTERVAL = 5
 PROCESSED_FOLDER = "Processed"
+REJECTED_FOLDER = "Rejected"
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +45,19 @@ def _get_poll_interval() -> int:
         return int(os.environ.get("POLL_INTERVAL", DEFAULT_POLL_INTERVAL))
     except ValueError:
         return DEFAULT_POLL_INTERVAL
+
+
+def _parse_whitelist(raw: str) -> set[str]:
+    return {addr.strip().lower() for addr in raw.split(",") if addr.strip()}
+
+
+def _extract_sender_address(raw_bytes: bytes) -> str | None:
+    try:
+        msg = email.message_from_bytes(raw_bytes)
+    except Exception:
+        return None
+    _, addr = parseaddr(msg.get("From", ""))
+    return addr.lower() if addr else None
 
 
 def _extract_audio_attachment(part: Message, download_dir: Path) -> Path | None:
@@ -110,6 +125,7 @@ class EmailClient:
         self._username = username or os.environ.get("IMAP_USERNAME", "")
         self._password = password or os.environ.get("IMAP_PASSWORD", "")
         self._client: IMAPClient | None = None
+        self._whitelist = _parse_whitelist(os.environ.get("SENDER_WHITELIST", ""))
 
     def connect(self) -> None:
         try:
@@ -123,8 +139,10 @@ class EmailClient:
             self._client = None
             raise AuthenticationError(f"Login failed for {self._username}: {e}")
 
+        self._delimiter = self._client.namespace().personal[0][1]
         self._client.select_folder("INBOX")
-        self._ensure_processed_folder()
+        self._ensure_folders()
+        logger.info("Sender whitelist: %d addresses", len(self._whitelist))
 
     def disconnect(self) -> None:
         if self._client:
@@ -142,12 +160,27 @@ class EmailClient:
         self.disconnect()
         return False
 
-    def _ensure_processed_folder(self) -> None:
+    def _is_sender_allowed(self, sender: str | None) -> bool:
+        return sender is not None and sender in self._whitelist
+
+    def _reject(self, uid: int) -> None:
         if not self._client:
             return
-        if not self._client.folder_exists(PROCESSED_FOLDER):
-            self._client.create_folder(PROCESSED_FOLDER)
-            logger.info("Created folder: %s", PROCESSED_FOLDER)
+        try:
+            self._client.move([uid], REJECTED_FOLDER)
+        except Exception as e:
+            logger.warning("Failed to move UID %d to %s: %s", uid, REJECTED_FOLDER, e)
+
+    def _ensure_folder(self, folder: str) -> None:
+        if not self._client:
+            return
+        if not self._client.folder_exists(folder):
+            self._client.create_folder(folder)
+            logger.info("Created folder: %s", folder)
+
+    def _ensure_folders(self) -> None:
+        for folder in (PROCESSED_FOLDER, REJECTED_FOLDER):
+            self._ensure_folder(folder)
 
     def fetch_unseen_emails(self, download_dir: Path) -> list[EmailMessage]:
         if not self._client:
@@ -173,17 +206,29 @@ class EmailClient:
                 logger.warning("No RFC822 data for UID %d, skipping", uid)
                 continue
 
+            sender = _extract_sender_address(raw_bytes)
+            if not self._is_sender_allowed(sender):
+                logger.info("UID %d from %s not in whitelist, rejecting", uid, sender)
+                self._reject(uid)
+                continue
+
             parsed = _parse_email(uid, raw_bytes, download_dir)
             if parsed:
                 results.append(parsed)
 
         return results
 
-    def mark_as_processed(self, uid: int) -> None:
+    def mark_as_processed(self, msg: EmailMessage) -> None:
         if not self._client:
             raise IMAPConnectionError("Not connected. Call connect() first.")
 
+        _, addr = parseaddr(msg.sender)
+        sep = self._delimiter
+        safe_addr = addr.lower().replace(sep, "_") if addr else None
+        folder = f"{PROCESSED_FOLDER}{sep}{safe_addr}" if safe_addr else PROCESSED_FOLDER
+        self._ensure_folder(folder)
+
         try:
-            self._client.move([uid], PROCESSED_FOLDER)
+            self._client.move([msg.uid], folder)
         except Exception as e:
-            raise FetchError(f"Failed to move UID {uid} to {PROCESSED_FOLDER}: {e}")
+            raise FetchError(f"Failed to move UID {msg.uid} to {folder}: {e}")


### PR DESCRIPTION
- Add SENDER_WHITELIST env var for comma-separated, case-insensitive sender filtering
- Reject non-whitelisted emails to a Rejected IMAP folder (prevents re-polling and inbox bloat)
- Organize processed emails into per-sender subfolders under Processed/
- Detect IMAP namespace delimiter to handle servers that use . as hierarchy separator
- Whitelist check runs before attachment extraction, so rejected emails never write to disk
- Empty/unset whitelist rejects all emails (strict default, no open-relay mode)