### PR TITLE
[feature]: Add SMTP email reply with transcript attachments and email threading support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,11 @@ POLL_INTERVAL=5
 # Output Configuration
 OUTPUT_DIR=
 
+# SMTP Configuration
+SMTP_HOST=
+SMTP_PORT=465
+SMTP_USERNAME=
+SMTP_PASSWORD=
+
 # Sender Whitelist (comma-separated email addresses)
 SENDER_WHITELIST=

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ venv/
 env/
 .env
 test_audio.mp3
+test.py
 
 # Cache
 __pycache__/
@@ -20,3 +21,4 @@ __pycache__/
 # Project-specific
 logs/
 *.log
+downloads/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-02-07
+
+### Added
+
+- `src/email_sender.py` - SMTP email reply with transcript attachment
+- `EmailSender` class with context manager support for SMTP connections
+- `send_transcript()` sends reply to original sender with `.txt` attachments
+- `In-Reply-To` and `References` headers for email threading
+- SMTP_SSL (port 465) and STARTTLS support
+- Custom error hierarchy: `EmailSenderError`, `SMTPConnectionError`, `SMTPAuthenticationError`, `SendError`
+- `message_id` field on `EmailMessage` dataclass for reply threading
+- `Message-ID` header extraction in `_parse_email()`
+- SMTP configuration in `.env.example` (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`)
+
 ## [0.3.0] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Email-based audio transcription service. Send an audio file, receive a transcrip
 | `IMAP_PORT` | IMAP server port | `993` |
 | `IMAP_USERNAME` | IMAP login username | (required) |
 | `IMAP_PASSWORD` | IMAP login password | (required) |
+| `SMTP_HOST` | SMTP server hostname | (required) |
+| `SMTP_PORT` | SMTP server port | `465` |
+| `SMTP_USERNAME` | SMTP login username | (required) |
+| `SMTP_PASSWORD` | SMTP login password | (required) |
 | `SENDER_WHITELIST` | Comma-separated allowed sender emails | (empty = reject all) |
 | `POLL_INTERVAL` | Seconds between inbox checks | `5` |
 | `FFMPEG_PATH` | Path to ffmpeg binary | system default |
@@ -58,8 +62,9 @@ Email-based audio transcription service. Send an audio file, receive a transcrip
 
 - `src/transcription.py` - audio-to-text via OpenAI Whisper API with ffmpeg normalization
 - `src/email_client.py` - IMAP connection, inbox polling, audio attachment extraction
+- `src/email_sender.py` - SMTP reply with transcript attachments, email threading
 
-Emails from whitelisted senders are processed and moved to `Processed/<sender>`. Non-whitelisted emails are moved to `Rejected`. Unset or empty `SENDER_WHITELIST` rejects all emails.
+Emails from whitelisted senders are processed and moved to `Processed/<sender>`. Non-whitelisted emails are moved to `Rejected`. Unset or empty `SENDER_WHITELIST` rejects all emails. Transcript replies are threaded under the original email via `In-Reply-To`/`References` headers.
 
 ## Usage
 

--- a/src/email_client.py
+++ b/src/email_client.py
@@ -38,6 +38,7 @@ class EmailMessage:
     sender: str
     subject: str
     attachment_paths: list[Path]
+    message_id: str | None = None
 
 
 def _get_poll_interval() -> int:
@@ -89,6 +90,7 @@ def _parse_email(
 
     sender = msg.get("From", "")
     subject = msg.get("Subject", "")
+    message_id = msg.get("Message-ID")
     attachment_paths: list[Path] = []
 
     for part in msg.walk():
@@ -109,6 +111,7 @@ def _parse_email(
         sender=sender,
         subject=subject,
         attachment_paths=attachment_paths,
+        message_id=message_id,
     )
 
 

--- a/src/email_sender.py
+++ b/src/email_sender.py
@@ -1,0 +1,119 @@
+import logging
+import os
+import smtplib
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formataddr, formatdate, parseaddr
+from pathlib import Path
+
+from .email_client import EmailMessage
+
+logger = logging.getLogger(__name__)
+
+
+class EmailSenderError(Exception):
+    pass
+
+
+class SMTPConnectionError(EmailSenderError):
+    pass
+
+
+class SMTPAuthenticationError(EmailSenderError):
+    pass
+
+
+class SendError(EmailSenderError):
+    pass
+
+
+class EmailSender:
+    def __init__(
+        self,
+        host: str | None = None,
+        port: int | None = None,
+        username: str | None = None,
+        password: str | None = None,
+    ):
+        self._host = host or os.environ.get("SMTP_HOST", "")
+        self._port = port or int(os.environ.get("SMTP_PORT", "465"))
+        self._username = username or os.environ.get("SMTP_USERNAME", "")
+        self._password = password or os.environ.get("SMTP_PASSWORD", "")
+        self._connection: smtplib.SMTP | smtplib.SMTP_SSL | None = None
+
+    def connect(self) -> None:
+        try:
+            if self._port == 465:
+                self._connection = smtplib.SMTP_SSL(self._host, self._port)
+            else:
+                self._connection = smtplib.SMTP(self._host, self._port)
+                self._connection.starttls()
+        except Exception as e:
+            raise SMTPConnectionError(
+                f"Failed to connect to {self._host}:{self._port}: {e}"
+            )
+
+        try:
+            self._connection.login(self._username, self._password)
+        except Exception as e:
+            self._connection = None
+            raise SMTPAuthenticationError(
+                f"SMTP login failed for {self._username}: {e}"
+            )
+
+        logger.info("Connected to SMTP server %s:%d", self._host, self._port)
+
+    def disconnect(self) -> None:
+        if self._connection:
+            try:
+                self._connection.quit()
+            except Exception:
+                pass
+            self._connection = None
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+        return False
+
+    def send_transcript(
+        self, original: EmailMessage, transcript_paths: list[Path]
+    ) -> None:
+        if not self._connection:
+            raise SMTPConnectionError("Not connected. Call connect() first.")
+
+        _, recipient = parseaddr(original.sender)
+        if not recipient:
+            raise SendError(f"Cannot parse recipient from: {original.sender}")
+
+        msg = MIMEMultipart()
+        msg["From"] = formataddr(("", self._username))
+        msg["To"] = recipient
+        msg["Date"] = formatdate(localtime=True)
+
+        subject = original.subject or ""
+        msg["Subject"] = f"Re: {subject}" if not subject.startswith("Re:") else subject
+
+        if original.message_id:
+            msg["In-Reply-To"] = original.message_id
+            msg["References"] = original.message_id
+
+        body = "Your audio file has been transcribed. The transcript is attached."
+        msg.attach(MIMEText(body, "plain"))
+
+        for path in transcript_paths:
+            with open(path, "rb") as f:
+                attachment = MIMEApplication(f.read(), Name=path.name)
+            attachment["Content-Disposition"] = f'attachment; filename="{path.name}"'
+            msg.attach(attachment)
+
+        try:
+            self._connection.sendmail(self._username, recipient, msg.as_string())
+        except Exception as e:
+            raise SendError(f"Failed to send reply to {recipient}: {e}")
+
+        logger.info("Sent transcript reply to %s", recipient)


### PR DESCRIPTION
- Added src/email_sender.py — SMTP client that replies to the original sender with .txt transcript attachments, supporting SMTP_SSL (port 465) and STARTTLS
- Added message_id field to EmailMessage dataclass and extracted Message-ID header in _parse_email() to enable reply threading via In-Reply-To/References
- Added SMTP env vars (SMTP_HOST, SMTP_PORT, SMTP_USERNAME, SMTP_PASSWORD) to .env.example
- Updated CHANGELOG.md and README.md